### PR TITLE
Add USER root to dockerfile so that additional files can be added (so…

### DIFF
--- a/docker/sonarqube-aws-env/Dockerfile
+++ b/docker/sonarqube-aws-env/Dockerfile
@@ -1,5 +1,5 @@
 FROM sonarqube:7.5-community
-
+USER root
 RUN curl -L https://github.com/telia-oss/aws-env/releases/download/v0.3.0/aws-env-linux-amd64 > /usr/local/bin/aws-env && \
       echo f80addd4adf9aa8d4ecf1b16de402ba4  /usr/local/bin/aws-env | md5sum -c && \
       chmod +x /usr/local/bin/aws-env


### PR DESCRIPTION
…narqube is run as sonarqube user when it gets there)


# Pull Request

## Description

USER needs to be escalated to root from default of sonarqube  so that aws-env exec can run (which then runs sonarqube with the user sonarqube)

Fixes # (issue)

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)