### PR TITLE
fix alias

### DIFF
--- a/modules/init/init.tf
+++ b/modules/init/init.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "sonarqube-parameters" {
 }
 
 resource "aws_kms_alias" "key-alias" {
-  name          = "alias/sonarqube-parameters"
+  name          = "alias/${var.name_prefix}-parameters"
   target_key_id = "${aws_kms_key.sonarqube-parameters.id}"
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Update key alias to use name_prefix to avoid name clashes when multiple instances launched on same account.

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)