### PR TITLE
replace hard coded instance type for cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ module "ecs_cluster" {
   source              = "telia-oss/ecs/aws//modules/cluster"
   version             = "0.4.1"
   instance_ami        = "${data.aws_ami.ecs.id}"
-  instance_type       = "t2.small"
+  instance_type       = "${var.cluster_instance_type}"
   name_prefix         = "${var.name_prefix}"
   vpc_id              = "${module.vpc.vpc_id}"
   subnet_ids          = ["${module.vpc.private_subnet_ids}"]


### PR DESCRIPTION
# Pull Request

## Description

Fix issue where cluster always launches on t2.small instances (variable was not used before)

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/` directories (look in CI for an example)
